### PR TITLE
Fixed Value "0" isn't displayed in output array.

### DIFF
--- a/src/Jackiedo/DotenvEditor/DotenvFormatter.php
+++ b/src/Jackiedo/DotenvEditor/DotenvFormatter.php
@@ -154,7 +154,7 @@ class DotenvFormatter implements DotenvFormatterContract
             $key    = $this->normaliseKey($key);
             $data   = trim($data);
 
-            if (!$data) {
+            if (!$data && $data !== "0") {
                 $value   = '';
                 $comment = '';
             } else {


### PR DESCRIPTION
For example:
> currency_decimals=0

Parser will not work properly and display value '' (Empty string).
If we build an ENV Editor, it will saves "empty string". So i fixed it to display value "0" in output array.
