### PR TITLE
Defer service provider registration

### DIFF
--- a/src/Jackiedo/DotenvEditor/DotenvEditorServiceProvider.php
+++ b/src/Jackiedo/DotenvEditor/DotenvEditorServiceProvider.php
@@ -16,7 +16,7 @@ class DotenvEditorServiceProvider extends ServiceProvider
      *
      * @var bool
      */
-    protected $defer = false;
+    protected $defer = true;
 
     /**
      * Bootstrap the application events.


### PR DESCRIPTION
Since I suppose we use features of this package rarely (certainly not on every request), it is worth defering registering of it's bindings to when they are actually needed.

https://laravel.com/docs/5.7/providers#deferred-providers

It supports Laravel up to 5.8, since when different implementation is needed.