### PR TITLE
Safety measure for getBackups()

### DIFF
--- a/src/Jackiedo/DotenvEditor/DotenvEditor.php
+++ b/src/Jackiedo/DotenvEditor/DotenvEditor.php
@@ -444,13 +444,13 @@ class DotenvEditor
      */
     public function getBackups()
     {
-        $backups = array_diff(scandir($this->backupPath), array('..', '.'));
+        $filenameRegex  = '/^' .preg_quote(self::BACKUP_FILENAME_PREFIX, '/'). '(\d{4})_(\d{2})_(\d{2})_(\d{2})(\d{2})(\d{2})' .preg_quote(self::BACKUP_FILENAME_SUFFIX, '/'). '$/';
+        $backups = array_filter(array_diff(scandir($this->backupPath), array('..', '.')), function($backup) use ($filenameRegex) {
+            return preg_match($filenameRegex, $backup);
+        });
         $output = [];
 
         foreach ($backups as $backup) {
-            $filenamePrefix = preg_quote(self::BACKUP_FILENAME_PREFIX, '/');
-            $filenameSuffix = preg_quote(self::BACKUP_FILENAME_SUFFIX, '/');
-            $filenameRegex  = '/^' .$filenamePrefix. '(\d{4})_(\d{2})_(\d{2})_(\d{2})(\d{2})(\d{2})' .$filenameSuffix. '$/';
 
             $datetime = preg_replace($filenameRegex, '$1-$2-$3 $4:$5:$6', $backup);
 


### PR DESCRIPTION
This fixes pretty severe bug, which happens, if we use a folder which is not empty for backupPath.

Current implementation simply returns all content of the folder, making no check, which content is actually relevant.

Example:

> You set backupPath to '/' and then use deleteBackups(). Since getBackups will return all files, the package will then remove your whole project ... which we don't want :)

My fix makes sure that only files that are actual backup files created by this package are taken into consideration.