### PR TITLE
Properly support current Laravel versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Latest Unstable Version](https://poser.pugx.org/jackiedo/dotenv-editor/v/unstable)](https://packagist.org/packages/jackiedo/dotenv-editor)
 [![License](https://poser.pugx.org/jackiedo/dotenv-editor/license)](https://packagist.org/packages/jackiedo/dotenv-editor)
 
-Laravel Dotenv Editor is the .env file editor (or files with same structure and syntax) for Laravel 5+. Now you can easily edit .env files with the following features:
+Laravel Dotenv Editor is the .env file editor (or files with same structure and syntax) for Laravel 5.8+. Now you can easily edit .env files with the following features:
 
 * Read raw content of file
 * Read lines of file content
@@ -42,7 +42,7 @@ Look at one of the following topics to learn more about Laravel Dotenv Editor
 * [Thanks from author](#thanks-for-use)
 
 ## Versions and compatibility
-Currently, only Laravel Dotenv Editor 1.x is compatible with Laravel 5+ and later. This package does not support Laravel 4.2 and earlier versions.
+Laravel Dotenv Editor is compatible with Laravel 5.8 and later. This package does not support earlier Laravel versions.
 
 ## Installation
 You can install this package through [Composer](https://getcomposer.org).
@@ -65,7 +65,7 @@ $ composer update
 
 > **Note:** Instead of performing the above two steps, it may be faster to use the command line `$ composer require jackiedo/dotenv-editor:1.*`.
 
-Since Laravel 5.5, [service providers and aliases are automatically registered](https://laravel.com/docs/5.5/packages#package-discovery). But if you are using Laravel 5.4 or earlier, you must perform these two steps:
+Since Laravel 5.5, [service providers and aliases are automatically registered](https://laravel.com/docs/5.5/packages#package-discovery), so you can safely skip the following two steps:
 
 - The third step is to register the service provider. Open `config/app.php`, and add a new item to the providers array:
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "jackiedo/dotenv-editor",
-    "description": "The .env file editor tool for Laravel 5+",
+    "description": "The .env file editor tool for Laravel 5.8+",
     "license": "MIT",
     "keywords": ["laravel", "dotenv", "dotenv-editor"],
     "authors": [
@@ -10,10 +10,9 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
-        "illuminate/config": ">=5.0",
-        "illuminate/container": ">=5.0",
-        "illuminate/support": ">=5.0"
+        "illuminate/console": "^5.8|^6.0|^7.0",
+        "illuminate/contracts": "^5.8|^6.0|^7.0",
+        "illuminate/support": "^5.8|^6.0|^7.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Jackiedo/DotenvEditor/DotenvEditor.php
+++ b/src/Jackiedo/DotenvEditor/DotenvEditor.php
@@ -17,14 +17,14 @@ class DotenvEditor
     /**
      * The IoC Container
      *
-     * @var \Illuminate\Container\Container
+     * @var \Illuminate\Contracts\Container\Container
      */
     protected $app;
 
     /**
      * Store instance of Config Repository;
      *
-     * @var \Illuminate\Config\Repository
+     * @var \Illuminate\Contracts\Config\Repository
      */
     protected $config;
 

--- a/src/Jackiedo/DotenvEditor/DotenvEditorServiceProvider.php
+++ b/src/Jackiedo/DotenvEditor/DotenvEditorServiceProvider.php
@@ -1,6 +1,7 @@
 <?php namespace Jackiedo\DotenvEditor;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Contracts\Support\DeferrableProvider;
 
 /**
  * DotenvEditorServiceProvider
@@ -8,16 +9,8 @@ use Illuminate\Support\ServiceProvider;
  * @package Jackiedo\DotenvEditor
  * @author Jackie Do <anhvudo@gmail.com>
  */
-class DotenvEditorServiceProvider extends ServiceProvider
+class DotenvEditorServiceProvider extends ServiceProvider implements DeferrableProvider
 {
-
-    /**
-     * Indicates if loading of the provider is deferred.
-     *
-     * @var bool
-     */
-    protected $defer = true;
-
     /**
      * Bootstrap the application events.
      *


### PR DESCRIPTION
This PR does the following:

1) It properly implements deferrable service provider, for Laravel 5.8+ (https://laravel.com/docs/5.8/upgrade#deferred-service-providers).

2) It properly specifies dependencies in composer.json. It also does not use greater or equal to sign (>=) anymore, since considering the semver it is not neccessary that all future Laravel versions will simply work.

The result is that this package is now compatibile only to Laravel 5.8 and newer. That shouldn't be a problem since all earlier versions have reached EOL long time ago already, and if we want to keep this package up to date to current standards that's a small price to pay.

I have also updated README to reflect these changes. The only thing left is to update the Github repository description to say "The .env file editor tool for Laravel 5.8+". 