### PR TITLE
Do not automatically create .gitignore

### DIFF
--- a/src/Jackiedo/DotenvEditor/DotenvEditor.php
+++ b/src/Jackiedo/DotenvEditor/DotenvEditor.php
@@ -175,7 +175,6 @@ class DotenvEditor
     {
         if (! is_dir($this->backupPath)) {
             mkdir($this->backupPath, 0777, true);
-            copy(__DIR__ . '/../../stubs/gitignore.txt', $this->backupPath . '../.gitignore');
         }
     }
 

--- a/src/stubs/gitignore.txt
+++ b/src/stubs/gitignore.txt
@@ -1,3 +1,0 @@
-/backups
-*
-!.gitignore


### PR DESCRIPTION
It is up to the developer/user to manage its VCS. They might use SVN or any other, or even not use VCS at all, so creating this file servers no purpose and is out of the scope of this package.
Additionally, there is no reason to have this file in production for example.